### PR TITLE
feat(visual): SVG species components, graphs and color system

### DIFF
--- a/frontend/src/components/grid/GridCell.tsx
+++ b/frontend/src/components/grid/GridCell.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import type { SpecimenType } from '../../types/simulation.types';
+import { PlanktonSvg, SardineSvg, SharkSvg, CrabSvg, ReefSvg, DeadSardineSvg, DeadSharkSvg } from '../species';
+
+interface GridCellProps {
+  specimenType: SpecimenType;
+  size: number;
+}
+
+const SvgMap: Partial<Record<SpecimenType, React.ComponentType<{ size: number }>>> = {
+  Plankton: PlanktonSvg,
+  Sardine: SardineSvg,
+  Shark: SharkSvg,
+  Crab: CrabSvg,
+  Reef: ReefSvg,
+  DeadSardine: DeadSardineSvg,
+  DeadShark: DeadSharkSvg,
+};
+
+export const GridCell = React.memo(({ specimenType, size }: GridCellProps) => {
+  const SvgComponent = SvgMap[specimenType];
+  return (
+    <div style={{ width: size, height: size, background: '#0d1b2a', border: '1px solid rgba(255,255,255,0.04)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      {SvgComponent && <SvgComponent size={Math.max(16, size - 4)} />}
+    </div>
+  );
+});
+
+GridCell.displayName = 'GridCell';

--- a/frontend/src/components/species/CrabSvg.tsx
+++ b/frontend/src/components/species/CrabSvg.tsx
@@ -1,0 +1,33 @@
+interface SpeciesSvgProps {
+  size?: number;
+  colorTheme?: 'default' | 'high-contrast';
+  animationEnabled?: boolean;
+}
+
+export function CrabSvg({ size = 32, colorTheme = 'default', animationEnabled = true }: SpeciesSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+      {/* Body — rounded rectangle top-down */}
+      <ellipse cx="16" cy="16" rx="8" ry="6" fill="#e07b39" />
+      {/* Shell pattern */}
+      <ellipse cx="16" cy="15" rx="5" ry="4" fill="#c85f20" fillOpacity="0.5" />
+      {/* Left claw */}
+      <path d="M8,14 Q3,10 2,13 Q1,16 5,17 Q7,17 8,16" fill="#c85f20" stroke="#a04818" strokeWidth="0.5" />
+      {/* Right claw */}
+      <path d="M24,14 Q29,10 30,13 Q31,16 27,17 Q25,17 24,16" fill="#c85f20" stroke="#a04818" strokeWidth="0.5" />
+      {/* Legs left */}
+      <line x1="10" y1="14" x2="6" y2="11" stroke="#a04818" strokeWidth="1.2" />
+      <line x1="10" y1="16" x2="5" y2="16" stroke="#a04818" strokeWidth="1.2" />
+      <line x1="10" y1="18" x2="6" y2="21" stroke="#a04818" strokeWidth="1.2" />
+      {/* Legs right */}
+      <line x1="22" y1="14" x2="26" y2="11" stroke="#a04818" strokeWidth="1.2" />
+      <line x1="22" y1="16" x2="27" y2="16" stroke="#a04818" strokeWidth="1.2" />
+      <line x1="22" y1="18" x2="26" y2="21" stroke="#a04818" strokeWidth="1.2" />
+      {/* Eyes */}
+      <circle cx="13" cy="12" r="1.5" fill="black" />
+      <circle cx="19" cy="12" r="1.5" fill="black" />
+      <circle cx="13.5" cy="11.5" r="0.5" fill="white" />
+      <circle cx="19.5" cy="11.5" r="0.5" fill="white" />
+    </svg>
+  );
+}

--- a/frontend/src/components/species/DeadSardineSvg.tsx
+++ b/frontend/src/components/species/DeadSardineSvg.tsx
@@ -1,0 +1,21 @@
+interface SpeciesSvgProps {
+  size?: number;
+  colorTheme?: 'default' | 'high-contrast';
+  animationEnabled?: boolean;
+}
+
+export function DeadSardineSvg({ size = 32, colorTheme = 'default', animationEnabled = false }: SpeciesSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+      {/* Body — same shape, desaturated */}
+      <ellipse cx="15" cy="16" rx="11" ry="6" fill="#4a5a6a" />
+      {/* Tail */}
+      <polygon points="26,16 30,12 30,20" fill="#3a4a5a" />
+      {/* Belly — faded */}
+      <ellipse cx="14" cy="17" rx="7" ry="3" fill="#5a6a7a" fillOpacity="0.4" />
+      {/* X Eye */}
+      <line x1="4" y1="13" x2="8" y2="17" stroke="#e8f4f8" strokeWidth="1.5" strokeOpacity="0.6" />
+      <line x1="8" y1="13" x2="4" y2="17" stroke="#e8f4f8" strokeWidth="1.5" strokeOpacity="0.6" />
+    </svg>
+  );
+}

--- a/frontend/src/components/species/DeadSharkSvg.tsx
+++ b/frontend/src/components/species/DeadSharkSvg.tsx
@@ -1,0 +1,23 @@
+interface SpeciesSvgProps {
+  size?: number;
+  colorTheme?: 'default' | 'high-contrast';
+  animationEnabled?: boolean;
+}
+
+export function DeadSharkSvg({ size = 32, colorTheme = 'default', animationEnabled = false }: SpeciesSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+      {/* Body — faded */}
+      <ellipse cx="15" cy="17" rx="13" ry="7" fill="#3a4a5a" />
+      <polygon points="2,17 6,13 6,21" fill="#2a3a4a" />
+      <polygon points="28,17 32,11 32,23" fill="#2a3a4a" />
+      {/* Dorsal fin */}
+      <polygon points="14,10 18,3 22,10" fill="#2e3e4e" />
+      {/* Belly */}
+      <ellipse cx="14" cy="19" rx="9" ry="3.5" fill="#4a5a6a" fillOpacity="0.4" />
+      {/* X Eye */}
+      <line x1="4" y1="14" x2="8" y2="18" stroke="#e8f4f8" strokeWidth="1.5" strokeOpacity="0.6" />
+      <line x1="8" y1="14" x2="4" y2="18" stroke="#e8f4f8" strokeWidth="1.5" strokeOpacity="0.6" />
+    </svg>
+  );
+}

--- a/frontend/src/components/species/PlanktonSvg.tsx
+++ b/frontend/src/components/species/PlanktonSvg.tsx
@@ -1,0 +1,32 @@
+interface SpeciesSvgProps {
+  size?: number;
+  colorTheme?: 'default' | 'high-contrast';
+  animationEnabled?: boolean;
+}
+
+export function PlanktonSvg({ size = 32, colorTheme = 'default', animationEnabled = true }: SpeciesSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+      {animationEnabled && (
+        <style>{`
+          @keyframes planktonPulse {
+            0%, 100% { transform: scale(1); opacity: 0.9; }
+            50% { transform: scale(1.1); opacity: 1; }
+          }
+          .plankton-body { transform-origin: center; animation: planktonPulse 2s ease-in-out infinite; }
+        `}</style>
+      )}
+      {/* Outer glow ring */}
+      <circle cx="16" cy="16" r="12" fill="#7ec8a0" fillOpacity="0.15" />
+      {/* Main body */}
+      <circle className={animationEnabled ? "plankton-body" : ""} cx="16" cy="16" r="8" fill="#7ec8a0" fillOpacity="0.75" />
+      {/* Inner nucleus */}
+      <circle cx="16" cy="16" r="4" fill="#a8e6c3" fillOpacity="0.9" />
+      {/* Tendrils */}
+      <line x1="16" y1="4" x2="16" y2="8" stroke="#7ec8a0" strokeWidth="1" strokeOpacity="0.6" />
+      <line x1="16" y1="24" x2="16" y2="28" stroke="#7ec8a0" strokeWidth="1" strokeOpacity="0.6" />
+      <line x1="4" y1="16" x2="8" y2="16" stroke="#7ec8a0" strokeWidth="1" strokeOpacity="0.6" />
+      <line x1="24" y1="16" x2="28" y2="16" stroke="#7ec8a0" strokeWidth="1" strokeOpacity="0.6" />
+    </svg>
+  );
+}

--- a/frontend/src/components/species/ReefSvg.tsx
+++ b/frontend/src/components/species/ReefSvg.tsx
@@ -1,0 +1,21 @@
+interface SpeciesSvgProps {
+  size?: number;
+  colorTheme?: 'default' | 'high-contrast';
+  animationEnabled?: boolean;
+}
+
+export function ReefSvg({ size = 32, colorTheme = 'default', animationEnabled = false }: SpeciesSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+      {/* Main rock body */}
+      <polygon points="6,26 4,20 8,14 12,10 18,8 24,12 28,18 26,26" fill="#8b7355" />
+      {/* Rock face texture */}
+      <polygon points="8,24 7,19 11,15 16,12 21,14 24,20 22,24" fill="#7a6245" />
+      {/* Coral/highlight top */}
+      <polygon points="12,10 16,4 20,8 18,8" fill="#9b8265" />
+      <polygon points="18,8 22,5 24,12 20,10" fill="#8b7255" />
+      {/* Shadow base */}
+      <ellipse cx="16" cy="26" rx="10" ry="2" fill="#5a4a35" fillOpacity="0.4" />
+    </svg>
+  );
+}

--- a/frontend/src/components/species/SardineSvg.tsx
+++ b/frontend/src/components/species/SardineSvg.tsx
@@ -1,0 +1,29 @@
+interface SpeciesSvgProps {
+  size?: number;
+  colorTheme?: 'default' | 'high-contrast';
+  animationEnabled?: boolean;
+}
+
+export function SardineSvg({ size = 32, colorTheme = 'default', animationEnabled = true }: SpeciesSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+      {animationEnabled && (
+        <style>{`
+          @keyframes sardineFin { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-1px); } }
+          .sardine-fin { transform-origin: center; animation: sardineFin 1.5s ease-in-out infinite; }
+        `}</style>
+      )}
+      {/* Body — elongated ellipse */}
+      <ellipse cx="15" cy="16" rx="11" ry="6" fill="#89b4d8" />
+      {/* Tail */}
+      <polygon points="26,16 30,12 30,20" fill="#5a8aaa" />
+      {/* Belly highlight */}
+      <ellipse cx="14" cy="17" rx="7" ry="3" fill="#b8d4e8" fillOpacity="0.5" />
+      {/* Dorsal fin */}
+      <path className={animationEnabled ? "sardine-fin" : ""} d="M10,10 Q14,6 18,10" stroke="#5a8aaa" strokeWidth="1.5" fill="none" />
+      {/* Eye */}
+      <circle cx="6" cy="15" r="2" fill="white" />
+      <circle cx="6.5" cy="15" r="1" fill="#1a2a3a" />
+    </svg>
+  );
+}

--- a/frontend/src/components/species/SharkSvg.tsx
+++ b/frontend/src/components/species/SharkSvg.tsx
@@ -1,0 +1,38 @@
+interface SpeciesSvgProps {
+  size?: number;
+  colorTheme?: 'default' | 'high-contrast';
+  animationEnabled?: boolean;
+}
+
+export function SharkSvg({ size = 32, colorTheme = 'default', animationEnabled = true }: SpeciesSvgProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+      {animationEnabled && (
+        <style>{`
+          @keyframes sharkSway { 0%, 100% { transform: translateX(0); } 50% { transform: translateX(1px); } }
+          .shark-body { transform-origin: center; animation: sharkSway 3s ease-in-out infinite; }
+        `}</style>
+      )}
+      <g className={animationEnabled ? "shark-body" : ""}>
+        {/* Main body — angular ellipse */}
+        <ellipse cx="15" cy="17" rx="13" ry="7" fill="#546e7a" />
+        {/* Snout — pointed */}
+        <polygon points="2,17 6,13 6,21" fill="#37474f" />
+        {/* Tail */}
+        <polygon points="28,17 32,11 32,23" fill="#37474f" />
+        {/* Dorsal fin — prominent */}
+        <polygon points="14,10 18,3 22,10" fill="#455a64" />
+        {/* Pectoral fin */}
+        <polygon points="10,19 8,26 16,21" fill="#455a64" />
+        {/* Belly */}
+        <ellipse cx="14" cy="19" rx="9" ry="3.5" fill="#78909c" fillOpacity="0.5" />
+        {/* Eye — cold, flat */}
+        <circle cx="6" cy="16" r="2" fill="#1a2a3a" />
+        <circle cx="6" cy="16" r="0.8" fill="#000" />
+        {/* Gill slits */}
+        <line x1="9" y1="13" x2="9" y2="20" stroke="#37474f" strokeWidth="0.8" />
+        <line x1="11" y1="12" x2="11" y2="21" stroke="#37474f" strokeWidth="0.8" />
+      </g>
+    </svg>
+  );
+}

--- a/frontend/src/components/species/index.ts
+++ b/frontend/src/components/species/index.ts
@@ -1,0 +1,7 @@
+export { PlanktonSvg } from './PlanktonSvg';
+export { SardineSvg } from './SardineSvg';
+export { SharkSvg } from './SharkSvg';
+export { CrabSvg } from './CrabSvg';
+export { ReefSvg } from './ReefSvg';
+export { DeadSardineSvg } from './DeadSardineSvg';
+export { DeadSharkSvg } from './DeadSharkSvg';

--- a/frontend/src/components/stats/BirthDeathGraph.tsx
+++ b/frontend/src/components/stats/BirthDeathGraph.tsx
@@ -1,0 +1,33 @@
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { palette } from '../../styles/palette';
+
+interface BirthDeathGraphProps {
+  birthsData: Array<{ snapshot: number; births: number }>;
+  deathsData: Array<{ snapshot: number; deaths: number }>;
+}
+
+export function BirthDeathGraph({ birthsData, deathsData }: BirthDeathGraphProps) {
+  // Merge into combined array
+  const data = birthsData.map((b, i) => ({
+    snapshot: b.snapshot,
+    births: b.births,
+    deaths: deathsData[i]?.deaths ?? 0,
+  }));
+  
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <h3 style={{ color: palette.textMuted, fontSize: 12, marginBottom: 8 }}>BIRTHS & DEATHS PER SNAPSHOT</h3>
+      <ResponsiveContainer width="100%" height={130}>
+        <BarChart data={data} margin={{ top: 5, right: 10, left: -20, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+          <XAxis dataKey="snapshot" tick={{ fill: palette.textMuted, fontSize: 10 }} />
+          <YAxis tick={{ fill: palette.textMuted, fontSize: 10 }} />
+          <Tooltip contentStyle={{ background: palette.panelBg, border: `1px solid ${palette.accent}`, fontSize: 11 }} />
+          <Legend wrapperStyle={{ fontSize: 11 }} />
+          <Bar dataKey="births" fill={palette.success} radius={[2,2,0,0]} />
+          <Bar dataKey="deaths" fill={palette.buttonDanger} radius={[2,2,0,0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/stats/PopulationGraph.tsx
+++ b/frontend/src/components/stats/PopulationGraph.tsx
@@ -1,0 +1,27 @@
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { palette } from '../../styles/palette';
+
+interface PopulationGraphProps {
+  data: Array<{ snapshot: number; plankton: number; sardine: number; shark: number; crab: number }>;
+}
+
+export function PopulationGraph({ data }: PopulationGraphProps) {
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <h3 style={{ color: palette.textMuted, fontSize: 12, marginBottom: 8 }}>POPULATION OVER TIME</h3>
+      <ResponsiveContainer width="100%" height={160}>
+        <LineChart data={data} margin={{ top: 5, right: 10, left: -20, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+          <XAxis dataKey="snapshot" tick={{ fill: palette.textMuted, fontSize: 10 }} />
+          <YAxis tick={{ fill: palette.textMuted, fontSize: 10 }} />
+          <Tooltip contentStyle={{ background: palette.panelBg, border: `1px solid ${palette.accent}`, fontSize: 11 }} />
+          <Legend wrapperStyle={{ fontSize: 11 }} />
+          <Line type="monotone" dataKey="plankton" stroke={palette.plankton} dot={false} strokeWidth={1.5} />
+          <Line type="monotone" dataKey="sardine" stroke={palette.sardine} dot={false} strokeWidth={1.5} />
+          <Line type="monotone" dataKey="shark" stroke={palette.shark} dot={false} strokeWidth={2} />
+          <Line type="monotone" dataKey="crab" stroke={palette.crab} dot={false} strokeWidth={1.5} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/stats/StatsPanel.tsx
+++ b/frontend/src/components/stats/StatsPanel.tsx
@@ -1,0 +1,32 @@
+import { PopulationGraph } from './PopulationGraph';
+import { BirthDeathGraph } from './BirthDeathGraph';
+import { palette } from '../../styles/palette';
+import { SimulationState } from '../../types/simulation.types';
+
+export function StatsPanel({ state }: { state: SimulationState }) {
+  const latestCounts = state.populationHistory[state.populationHistory.length - 1];
+  
+  return (
+    <div className="stats-panel">
+      <h2>Ocean Statistics</h2>
+      <div className="snapshot-badge" style={{ color: palette.accent, fontSize: 13, marginBottom: 12 }}>
+        Snapshot #{state.snapshotNumber}
+      </div>
+      
+      {/* Current population counts */}
+      {latestCounts && (
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginBottom: 16 }}>
+          {(['plankton', 'sardine', 'shark', 'crab'] as const).map(species => (
+            <div key={species} style={{ background: palette.panelBg, borderRadius: 6, padding: '8px 10px', borderLeft: `3px solid ${palette[species]}` }}>
+              <div style={{ fontSize: 11, color: palette.textMuted, textTransform: 'capitalize' }}>{species}</div>
+              <div style={{ fontSize: 20, fontWeight: 700, color: palette[species] }}>{latestCounts[species]}</div>
+            </div>
+          ))}
+        </div>
+      )}
+      
+      <PopulationGraph data={state.populationHistory} />
+      <BirthDeathGraph birthsData={state.birthsHistory} deathsData={state.deathsHistory} />
+    </div>
+  );
+}

--- a/frontend/src/components/stats/index.ts
+++ b/frontend/src/components/stats/index.ts
@@ -1,0 +1,3 @@
+export { StatsPanel } from './StatsPanel';
+export { PopulationGraph } from './PopulationGraph';
+export { BirthDeathGraph } from './BirthDeathGraph';

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,31 @@
+:root {
+  --bg: #0a1628;
+  --panel-bg: #0f1f3d;
+  --cell-water: #0d1b2a;
+  --text: #e8f4f8;
+  --text-muted: #7a9bb5;
+  --accent: #00b4d8;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { background: var(--bg); color: var(--text); font-family: Inter, system-ui, sans-serif; }
+
+.app-layout { height: 100vh; display: flex; flex-direction: column; }
+.simulation-layout { display: flex; flex: 1; overflow: hidden; }
+.left-panel { flex: 1; overflow: auto; padding: 16px; display: flex; flex-direction: column; gap: 12px; }
+.right-panel { width: 380px; background: var(--panel-bg); overflow-y: auto; padding: 16px; border-left: 1px solid rgba(255,255,255,0.1); }
+.stats-panel h2 { color: var(--accent); font-size: 14px; font-weight: 600; margin-bottom: 12px; letter-spacing: 0.05em; text-transform: uppercase; }
+
+/* Buttons */
+.btn { padding: 8px 16px; border-radius: 6px; border: none; cursor: pointer; font-size: 13px; font-weight: 500; transition: all 0.15s; }
+.btn-primary { background: #0096c7; color: white; }
+.btn-primary:hover { background: #007ea8; }
+.btn-secondary { background: #1e3a5f; color: #e8f4f8; border: 1px solid #2a5080; }
+.btn-secondary:hover { background: #2a4a72; }
+.btn-danger { background: #c0392b; color: white; }
+.btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* Inputs */
+input[type="number"], select { background: #0f1f3d; border: 1px solid #1e4060; color: #e8f4f8; padding: 6px 10px; border-radius: 4px; font-size: 13px; width: 100%; }
+label { font-size: 12px; color: #7a9bb5; display: block; margin-bottom: 4px; }
+.form-group { margin-bottom: 12px; }

--- a/frontend/src/styles/palette.ts
+++ b/frontend/src/styles/palette.ts
@@ -1,0 +1,34 @@
+export const palette = {
+  // Ocean environment
+  background: '#0a1628',
+  panelBg: '#0f1f3d',
+  cellWater: '#0d1b2a',
+  cellBorder: 'rgba(255,255,255,0.05)',
+  text: '#e8f4f8',
+  textMuted: '#7a9bb5',
+  accent: '#00b4d8',
+  accentHover: '#0096c7',
+  
+  // Species colors (use consistently in SVGs AND graphs)
+  plankton: '#7ec8a0',      // soft green
+  planktonDark: '#4a9970',
+  sardine: '#89b4d8',       // silver-blue
+  sardineDark: '#5a8aaa',
+  shark: '#546e7a',         // dark slate-blue
+  sharkDark: '#37474f',
+  crab: '#e07b39',          // warm orange
+  crabDark: '#b85c20',
+  reef: '#8b7355',          // stone brown
+  reefDark: '#6b5535',
+  dead: '#4a5a6a',          // muted grey-blue
+  deadDark: '#2a3a4a',
+  
+  // UI
+  buttonPrimary: '#0096c7',
+  buttonSecondary: '#1e3a5f',
+  buttonDanger: '#c0392b',
+  inputBg: '#0f1f3d',
+  inputBorder: '#1e4060',
+  success: '#27ae60',
+  warning: '#f39c12',
+};


### PR DESCRIPTION
Implements GitHub Issues #12, #13, #14

## Changes
- 7 SVG species components (JSX, no string blobs)
- Animations: plankton pulse, sardine fin, shark sway (all toggleable)
- Dead variants: faded palette + X-eyes
- PopulationGraph (LineChart), BirthDeathGraph (BarChart) via Recharts
- StatsPanel with live population counters
- palette.ts: unified color system
- global.css: dark ocean theme

Closes #12 #13 #14